### PR TITLE
Fix metadata source for calendar sync schedules

### DIFF
--- a/backend/services/schedule_service.py
+++ b/backend/services/schedule_service.py
@@ -225,7 +225,7 @@ class ScheduleService:
                     user_id=user_id,
                     date=date,
                     tasks=calendar_tasks,
-                    source="calendar"
+                    source="calendar_sync"
                 )
                 
                 # Add calendar-specific metadata
@@ -247,7 +247,7 @@ class ScheduleService:
             metadata.update({
                 "generatedAt": format_timestamp(),
                 "lastModified": format_timestamp(),
-                "source": "calendar",
+                "source": "calendar_sync",
                 "calendarSynced": True,
                 "calendarEvents": len(calendar_tasks)
             })


### PR DESCRIPTION
## Summary
- fix schedule service to record `calendar_sync` metadata when merging calendar events

## Testing
- `pytest backend/tests/test_schedule_dupe.py::TestScheduleDuplicationFix::test_submit_data_updates_existing_schedule_with_valid_token -q` *(fails: No module named 'bson')*

------
https://chatgpt.com/codex/tasks/task_e_68888345216c8327b17223170b142803